### PR TITLE
Add ability to resolve packages in alternate pypi urls.

### DIFF
--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -171,8 +171,6 @@ def get_requirements_and_latest(filename, force=False):
         if spec_ver or force:
             latest_ver = latest_version(req, session, finder)
             yield (orig_line, req, spec_ver, latest_ver)
-        else:
-            yield (orig_line, None, None, None)
 
 
 def parse_requirement(line, filename, line_number, session, finder):
@@ -202,9 +200,6 @@ def current_version(req):
 
     :param req:    Instance of pip.req.req_install.InstallRequirement.
     """
-
-    if not req or not req.req:
-        return None
 
     eq_ver = None
     gt_ver = None

--- a/tests/samples/requirements-with-alt-index-url.txt
+++ b/tests/samples/requirements-with-alt-index-url.txt
@@ -1,0 +1,7 @@
+--index-url=http://pypi.example.com
+--trusted-host=pypi.example.com
+
+--extra-index-url=https://pypi.example2.com
+
+.
+flask

--- a/tests/test_pur.py
+++ b/tests/test_pur.py
@@ -471,24 +471,24 @@ class BaseTestCase(utils.TestCase):
                 super(PackageFinderSpy, self).__init__(*args, **kwargs)
                 PackageFinderSpy._spy = self
 
-        with utils.mock.patch('pur.PackageFinder', wraps=PackageFinderSpy) as mock_finder, \
-                 utils.mock.patch('pip.index.PackageFinder.find_all_candidates') as mock_find_all_candidates:
+        with utils.mock.patch('pur.PackageFinder', wraps=PackageFinderSpy) as mock_finder:
+            with utils.mock.patch('pip.index.PackageFinder.find_all_candidates') as mock_find_all_candidates:
 
-            project = 'flask'
-            version = '12.1'
-            link = Link('')
-            candidate = InstallationCandidate(project, version, link)
-            mock_find_all_candidates.return_value = [candidate]
+                project = 'flask'
+                version = '12.1'
+                link = Link('')
+                candidate = InstallationCandidate(project, version, link)
+                mock_find_all_candidates.return_value = [candidate]
 
-            self.runner.invoke(pur, args)
+                self.runner.invoke(pur, args)
 
-            self.assertTrue(mock_finder.called)
+                self.assertTrue(mock_finder.called)
 
-            self.assertEqual(
-                PackageFinderSpy._spy.index_urls,
-                ['http://pypi.example.com', 'https://pypi.example2.com']
-            )
-            self.assertEqual(
-                PackageFinderSpy._spy.secure_origins,
-                [('*', 'pypi.example.com', '*')]
-            )
+                self.assertEqual(
+                    PackageFinderSpy._spy.index_urls,
+                    ['http://pypi.example.com', 'https://pypi.example2.com']
+                )
+                self.assertEqual(
+                    PackageFinderSpy._spy.secure_origins,
+                    [('*', 'pypi.example.com', '*')]
+                )


### PR DESCRIPTION
Finder now updates itself with options found in requirements.txt

New test case primarily focuses on:
  --index-url
  --extra-index-url
  --trusted-host