### PR TITLE
Allow support for overriding the default PyPI index url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,8 @@ Options
                          requirements.txt file.
 -n, --no-recursive       Prevents updating nested requirements files.
 -s, --skip TEXT          Comma separated list of packages to skip updating.
+--index-url TEXT         Base URL of the Python Package Index. Can be
+                         provided multiple times for extra index urls.
 --only TEXT              Comma separated list of packages. Only these
                          packages will be updated.
 -m, --minor TEXT         Comma separated list of packages to only update

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -120,7 +120,7 @@ def pur(**options):
         dry_run=options['dry_run'],
         no_recursive=options['no_recursive'],
         echo=options['echo'],
-        index_urls=options['index_urls'],
+        index_urls=options['index_url'],
     )
 
     if not options['dry_run']:
@@ -135,7 +135,7 @@ def pur(**options):
 def update_requirements(input_file=None, output_file=None, force=False,
                         interactive=False, skip=[], only=[], minor=[],
                         patch=[], pre=[], dry_run=False,
-                        no_recursive=False, echo=False, index_url=[]):
+                        no_recursive=False, echo=False, index_urls=[]):
     """Update a requirements file.
 
     Returns a dict of package update info.
@@ -156,7 +156,7 @@ def update_requirements(input_file=None, output_file=None, force=False,
                          minor or major.
     :param pre:          List of packages to allow updating to pre-release
                          versions.
-    :param index_url:   List of PyPI index urls.
+    :param index_urls:   List of PyPI index urls.
     """
 
     obuffer = StringIO()
@@ -166,7 +166,7 @@ def update_requirements(input_file=None, output_file=None, force=False,
     _patch_pip(obuffer, updates, input_file=input_file, output_file=output_file,
               force=force, interactive=interactive, skip=skip, only=only,
               minor=minor, patch=patch, pre=pre, dry_run=dry_run,
-              no_recursive=no_recursive, echo=echo, index_url=index_url)
+              no_recursive=no_recursive, echo=echo, index_urls=index_urls)
 
     _internal_update_requirements(obuffer, updates,
                                   input_file=input_file,
@@ -181,7 +181,7 @@ def update_requirements(input_file=None, output_file=None, force=False,
                                   dry_run=dry_run,
                                   no_recursive=no_recursive,
                                   echo=echo,
-                                  index_url=index_url,
+                                  index_urls=index_urls,
                                   )
 
     if not dry_run:

--- a/tests/samples/requirements-with-alt-index-url.txt
+++ b/tests/samples/requirements-with-alt-index-url.txt
@@ -1,7 +1,7 @@
 --index-url=http://pypi.example.com
 --trusted-host=pypi.example.com
 
---extra-index-url=https://pypi.example2.com
+--extra-index-url=https://pypi2.example.com
 
 .
 flask


### PR DESCRIPTION
Allow support for overriding the default PyPI index URL to use URLs pointed at a mirror.

**Why**
Corporate environments often require developers to use a repository mirror and the mirror is not always explicitly defined in the `requirements.txt` file.

**Example use case**:
```shell
 pur --index-url https://test.pypi.org/simple
```

**Issue:**
https://github.com/alanhamlett/pip-update-requirements/issues/25