### PR TITLE
Indicate support for additional Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Build Tools',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py34, py35, py36, py37, py38, py39
 [testenv]
 deps = -rdev-requirements.txt
 commands = nosetests


### PR DESCRIPTION
Update classifiers to indicate support for newer Python versions (3.8 and 3.9) and update tests accordingly.