### PR TITLE
Show warning for invalid packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Options
                          file.
 -d, --dry-run            Output changes to STDOUT instead of overwriting the
                          requirements.txt file.
---dry-run-changed        When running with --dry-run, only output packages
+--dry-run-changed        When running with --dry-run-changed, only output packages
                          with updates, not packages that are already the
                          latest.
 -n, --no-recursive       Prevents updating nested requirements files.

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -263,7 +263,7 @@ def _update_requirements(obuffer, updates, input_file=None,
     stop = False
     for line, req, spec_ver, latest_ver in requirements:
 
-        if not stop and can_check_version(req, spec_ver, skip, skip_gt, only):
+        if not stop and latest_ver and can_check_version(req, spec_ver, skip, skip_gt, only):
 
             try:
                 if should_update(req, spec_ver, latest_ver, force=force,
@@ -309,6 +309,13 @@ def _update_requirements(obuffer, updates, input_file=None,
                 stop = True
                 if not dry_run_changed:
                     obuffer.write(line)
+
+        elif not latest_ver and not output_buffer:
+            if not dry_run_changed:
+                msg = 'Package {package} not found'.format(package=req.name)
+                if echo and not dry_run:
+                        _echo(msg)
+                obuffer.write(line)
 
         elif not output_buffer or not requirements_line(line, req):
             if not dry_run_changed:

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -312,7 +312,12 @@ def _update_requirements(obuffer, updates, input_file=None,
 
         elif not latest_ver and not output_buffer:
             if not dry_run_changed:
-                msg = 'Package {package} not found'.format(package=req.name)
+                msg = 'Could not find a version that satisfies the ' \
+                      'requirement {package} (from -r req.txt (line 1))' \
+                      ' (from versions: {version})'.format(
+                    package=req.name,
+                    version=latest_ver
+                    )
                 if echo and not dry_run:
                         _echo(msg)
                 obuffer.write(line)

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -312,9 +312,9 @@ def _update_requirements(obuffer, updates, input_file=None,
 
         elif not latest_ver and not output_buffer:
             if not dry_run_changed:
-                msg = 'Could not find a version that satisfies the ' \
+                msg = '\033[91mCould not find a version that satisfies the ' \
                       'requirement {package} (from -r req.txt (line 1))' \
-                      ' (from versions: {version})'.format(
+                      ' (from versions: {version})\033[0m'.format(
                     package=req.name,
                     version=latest_ver
                     )

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -318,7 +318,7 @@ def _update_requirements(obuffer, updates, input_file=None,
                     package=req.name,
                     version=latest_ver
                     )
-                if echo and not dry_run:
+                if echo:
                         _echo(msg)
                 obuffer.write(line)
 

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -310,16 +310,17 @@ def _update_requirements(obuffer, updates, input_file=None,
                 if not dry_run_changed:
                     obuffer.write(line)
 
-        elif not latest_ver and not output_buffer:
+        elif req and not latest_ver and not output_buffer:
             if not dry_run_changed:
                 msg = '\033[91mCould not find a version that satisfies the ' \
-                      'requirement {package} (from -r req.txt (line 1))' \
+                      'requirement {package} (from -r {output_file} (line 1))' \
                       ' (from versions: {version})\033[0m'.format(
                     package=req.name,
+                    output_file=input_file,
                     version=latest_ver
                     )
                 if echo:
-                        _echo(msg)
+                    _echo(msg)
                 obuffer.write(line)
 
         elif not output_buffer or not requirements_line(line, req):


### PR DESCRIPTION
Add warning for non existent packages, with output in terminal `Could not find a version that satisfies the requirement non-existent-package (from -r req.txt (line 1)) (from versions: none)`.

<img width="569" alt="Screenshot 2023-05-18 at 11 44 16 PM" src="https://github.com/alanhamlett/pip-update-requirements/assets/1073594/d45cd961-64e8-44cf-a563-246e280d843a">



Address issue  https://github.com/alanhamlett/pip-update-requirements/issues/36