### PR TITLE
Add compatibility with pip 24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '>=3.12.0-rc.1']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     name: Run Tests with Python ${{ matrix.python-version }}
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -28,7 +28,7 @@ jobs:
         run: pytest --cov=./pur --cov-report=xml
       -
         name: Upload Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests

--- a/pur/__init__.py
+++ b/pur/__init__.py
@@ -447,7 +447,7 @@ def _parse_requirements(filename, finder, session, updates=None, **options):
 
 class PatchedRequirementsFileParser(RequirementsFileParser):
 
-    def _parse_and_recurse(self, filename, constraint):
+    def _parse_and_recurse(self, filename, constraint, *args, **kwargs):
         for line, orig_line in self._parse_file(filename, constraint):
             if (
                 line is not None and


### PR DESCRIPTION
Currently, when using Pur directly from Python as per the documentation:
`>>> from pur import update_requirements`
`>>> print([x[0]['message'] for x in update_requirements(input_file='requirements.txt').values()])`

there is an error with pip version 24, and maybe 23 too:

> Traceback (most recent call last):
  File "C:\Users\me\requirements_update.py", line 73, in <module>
    for x in update_requirements(
             ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\me\AppData\Local\Programs\Python\Python312\Lib\site-packages\pur\__init__.py", line 201, in update_requirements
    _update_requirements(
  File "C:\Users\me\AppData\Local\Programs\Python\Python312\Lib\site-packages\pur\__init__.py", line 267, in _update_requirements
    for line, req, spec_ver, latest_ver in requirements:
  File "C:\Users\me\AppData\Local\Programs\Python\Python312\Lib\site-packages\pur\__init__.py", line 387, in _get_requirements_and_latest
    for parsed_req, orig_line in requirements:
  File "C:\Users\me\AppData\Local\Programs\Python\Python312\Lib\site-packages\pur\__init__.py", line 434, in _parse_requirements
    for parsed_line, orig_line in parser.parse(filename, constraint):
  File "C:\Users\me\AppData\Local\Programs\Python\Python312\Lib\site-packages\pip\_internal\req\req_file.py", line 332, in parse
    yield from self._parse_and_recurse(
               ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PatchedRequirementsFileParser._parse_and_recurse() takes 3 positional arguments but 4 were given

It seems that pip._internal.req.req_file._parse_and_recurse, which is overridden in pur (in class PatchedRequirementsFileParser) evolved, and it no requires 4 inputs instead of 3 (parsed_files_stack seems to have been added)

This PR aims to quickly make the overriding method compatible with Pip, no matter the version.