### PR TITLE
Add basic `pyproject.toml` to explicitly opting into PEP 517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
fixes #67 by adding basic `pyproject.toml` per [documentation](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#where-to-start) to explicitly opt-in PEP 517 and avoid deprecation warnings