### PR TITLE
build and publish a wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	@rm -f dist/*
 
 build:
-	@python ./setup.py sdist
+	@python -m build
 
 upload:
 	@twine upload ./dist/*


### PR DESCRIPTION
... in addition to publishing a source distribution.

Also direct invocation of setup.py is deprecated, so switch to approved tooling.

You may need to `pip install build` - just as (presumably) you today need to `pip install twine` for publishing.